### PR TITLE
Return exit code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { spawnSync } from 'child_process';
 dotenv.config({ silent: true });
 
 const args = process.argv.slice(2);
-spawnSync(
+const res = spawnSync(
   args[0],
   args.slice(1),
   {
@@ -12,3 +12,9 @@ spawnSync(
     stdio: 'inherit',
   },
 );
+
+if (res.status) {
+	process.exit(res.status);
+} else if (res.error) {
+	process.exit(1);
+}


### PR DESCRIPTION
`run.env` ignores the exit code from whatever it runs, so jobs always appear to succeed.

This PR checks for an error or non-zero status code, and exits using a non-zero code if found.