### PR TITLE
Implemented dotenv path option via -p argument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,26 @@
 import dotenv from 'dotenv';
+import path from 'path';
 import { spawnSync } from 'child_process';
 
-dotenv.config({ silent: true });
+let args = process.argv.slice(2);
+const opts = {
+  silent: true
+};
 
-const args = process.argv.slice(2);
+// Check if a path option has been passed.
+if (args[0] === '-p') {
+  Object.assign(opts, {
+    path: path.resolve(process.cwd(), args[1])
+  });
+  // remove both args.
+  args.splice(0, 2)
+}
+
+dotenv.config(opts);
+
 const res = spawnSync(
   args[0],
-  args.slice(1),
-  {
+  args.slice(1), {
     env: process.env,
     stdio: 'inherit',
   },


### PR DESCRIPTION
Allows for passing a custom path to your `.env` file via a `-p` argument. 